### PR TITLE
[FEK-23] Add custom renderer for 'code' type of node 

### DIFF
--- a/components/definition/definition.tsx
+++ b/components/definition/definition.tsx
@@ -1,4 +1,5 @@
 import ReactMarkdown from 'react-markdown/with-html'
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 
 import styles from './definition.module.scss'
 
@@ -8,6 +9,11 @@ export type DefinitionProps = {
   readonly answer: string
 }
 
+// Take 'code' node type and render it through 'SyntaxHighlighter'
+const CodeBlock = ({ language, value }) => {
+  return <SyntaxHighlighter language={language}>{value}</SyntaxHighlighter>
+}
+
 export function Definition({ id, question, answer }: DefinitionProps): JSX.Element {
   return (
     <article id={id} className={styles.definition}>
@@ -15,7 +21,7 @@ export function Definition({ id, question, answer }: DefinitionProps): JSX.Eleme
         <p>{question}</p>
       </header>
       <section className={styles.definitionContent}>
-        <ReactMarkdown source={answer} />
+        <ReactMarkdown source={answer} renderers={{ code: CodeBlock }} />
       </section>
     </article>
   )


### PR DESCRIPTION
Add custom renderer for 'code' type of node - using SyntaxHighlighter

^FEK-23 review